### PR TITLE
bgpd: add missing white-space between route short status and network …

### DIFF
--- a/bgpd/bgp_addpath.h
+++ b/bgpd/bgp_addpath.h
@@ -25,7 +25,7 @@ struct bgp_paths_limit_capability {
 	uint16_t afi;
 	uint8_t safi;
 	uint16_t paths_limit;
-};
+} __attribute__((packed));
 
 #define BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE 1
 

--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2249,7 +2249,7 @@ void aspath_finish(void)
 /* return and as path value */
 const char *aspath_print(struct aspath *as)
 {
-	return (as ? as->str : NULL);
+	return as ? as->str : "(null)";
 }
 
 /* Printing functions */

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -911,9 +911,16 @@ static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)
 
 	vty_out(vty,
 		"\tflags: %" PRIu64
-		" distance: %u med: %u local_pref: %u origin: %u weight: %u label: %u sid: %pI6\n",
+		" distance: %u med: %u local_pref: %u origin: %u weight: %u label: %u sid: %pI6 aigp_metric: %" PRIu64
+		"\n",
 		attr->flag, attr->distance, attr->med, attr->local_pref,
-		attr->origin, attr->weight, attr->label, sid);
+		attr->origin, attr->weight, attr->label, sid, attr->aigp_metric);
+	vty_out(vty,
+		"\taspath: %s Community: %s Extended Community: %s Large Community: %s\n",
+		aspath_print(attr->aspath),
+		community_str(attr->community, false, false),
+		ecommunity_str(attr->ecommunity),
+		lcommunity_str(attr->lcommunity, false, false));
 }
 
 void attr_show_all(struct vty *vty)

--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -122,8 +122,9 @@ static void bgp_conditional_adv_routes(struct peer *peer, afi_t afi,
 			if (update_type == UPDATE_TYPE_ADVERTISE &&
 			    subgroup_announce_check(dest, pi, subgrp, dest_p,
 						    &attr, &advmap_attr)) {
-				bgp_adj_out_set_subgroup(dest, subgrp, &attr,
-							 pi);
+				if (!bgp_adj_out_set_subgroup(dest, subgrp,
+							      &attr, pi))
+					bgp_attr_flush(&attr);
 			} else {
 				/* If default originate is enabled for
 				 * the peer, do not send explicit

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -263,8 +263,11 @@ struct ecommunity *ecommunity_dup(struct ecommunity *ecom)
 }
 
 /* Return string representation of ecommunities attribute. */
-char *ecommunity_str(struct ecommunity *ecom)
+const char *ecommunity_str(struct ecommunity *ecom)
 {
+	if (!ecom)
+		return "(null)";
+
 	if (!ecom->str)
 		ecom->str =
 			ecommunity_ecom2str(ecom, ECOMMUNITY_FORMAT_DISPLAY, 0);

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -346,7 +346,7 @@ extern void ecommunity_strfree(char **s);
 extern bool ecommunity_include(struct ecommunity *e1, struct ecommunity *e2);
 extern bool ecommunity_match(const struct ecommunity *,
 			     const struct ecommunity *);
-extern char *ecommunity_str(struct ecommunity *ecom);
+extern const char *ecommunity_str(struct ecommunity *ecom);
 extern struct ecommunity_val *ecommunity_lookup(const struct ecommunity *,
 						uint8_t, uint8_t);
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3240,11 +3240,13 @@ static void bgp_dynamic_capability_paths_limit(uint8_t *pnt, int action,
 			safi_t safi;
 			iana_afi_t pkt_afi;
 			iana_safi_t pkt_safi;
+			uint16_t paths_limit = 0;
 			struct bgp_paths_limit_capability bpl = {};
 
 			memcpy(&bpl, data, sizeof(bpl));
 			pkt_afi = ntohs(bpl.afi);
 			pkt_safi = safi_int2iana(bpl.safi);
+			paths_limit = ntohs(bpl.paths_limit);
 
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%s OPEN has %s capability for afi/safi: %s/%s limit: %u",
@@ -3252,8 +3254,7 @@ static void bgp_dynamic_capability_paths_limit(uint8_t *pnt, int action,
 					   lookup_msg(capcode_str, hdr->code,
 						      NULL),
 					   iana_afi2str(pkt_afi),
-					   iana_safi2str(pkt_safi),
-					   bpl.paths_limit);
+					   iana_safi2str(pkt_safi), paths_limit);
 
 			if (bgp_map_afi_safi_iana2int(pkt_afi, pkt_safi, &afi,
 						      &safi)) {
@@ -3275,7 +3276,7 @@ static void bgp_dynamic_capability_paths_limit(uint8_t *pnt, int action,
 			SET_FLAG(peer->af_cap[afi][safi],
 				 PEER_CAP_PATHS_LIMIT_AF_RCV);
 			peer->addpath_paths_limit[afi][safi].receive =
-				bpl.paths_limit;
+				paths_limit;
 ignore:
 			data += CAPABILITY_CODE_PATHS_LIMIT_LEN;
 		}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6006,10 +6006,10 @@ bool bgp_outbound_policy_exists(struct peer *peer, struct bgp_filter *filter)
 	if (peer->sort == BGP_PEER_IBGP)
 		return true;
 
-	if (peer->sort == BGP_PEER_EBGP
-	    && (ROUTE_MAP_OUT_NAME(filter) || PREFIX_LIST_OUT_NAME(filter)
-		|| FILTER_LIST_OUT_NAME(filter)
-		|| DISTRIBUTE_OUT_NAME(filter)))
+	if (peer->sort == BGP_PEER_EBGP &&
+	    (ROUTE_MAP_OUT_NAME(filter) || PREFIX_LIST_OUT_NAME(filter) ||
+	     FILTER_LIST_OUT_NAME(filter) || DISTRIBUTE_OUT_NAME(filter) ||
+	     UNSUPPRESS_MAP_NAME(filter)))
 		return true;
 	return false;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2979,7 +2979,7 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 {
 	const struct prefix *p;
 	struct peer *onlypeer;
-	struct attr attr;
+	struct attr attr = { 0 }, *pattr = &attr;
 	struct bgp *bgp;
 	bool advertise;
 
@@ -3007,26 +3007,30 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 	advertise = bgp_check_advertise(bgp, dest, safi);
 
 	if (selected) {
-		if (subgroup_announce_check(dest, selected, subgrp, p, &attr,
+		if (subgroup_announce_check(dest, selected, subgrp, p, pattr,
 					    NULL)) {
 			/* Route is selected, if the route is already installed
 			 * in FIB, then it is advertised
 			 */
 			if (advertise) {
 				if (!bgp_check_withdrawal(bgp, dest, safi)) {
-					struct attr *adv_attr =
-						bgp_attr_intern(&attr);
-
-					bgp_adj_out_set_subgroup(dest, subgrp,
-								 adv_attr,
-								 selected);
-				} else
+					if (!bgp_adj_out_set_subgroup(dest,
+								      subgrp,
+								      pattr,
+								      selected))
+						bgp_attr_flush(pattr);
+				} else {
 					bgp_adj_out_unset_subgroup(
 						dest, subgrp, 1, addpath_tx_id);
-			}
-		} else
+					bgp_attr_flush(pattr);
+				}
+			} else
+				bgp_attr_flush(pattr);
+		} else {
 			bgp_adj_out_unset_subgroup(dest, subgrp, 1,
 						   addpath_tx_id);
+			bgp_attr_flush(pattr);
+		}
 	}
 
 	/* If selected is NULL we must withdraw the path using addpath_tx_id */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2242,7 +2242,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	}
 
 	/* AS path loop check. */
-	if (peer->as_path_loop_detection &&
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_AS_LOOP_DETECTION) &&
 	    aspath_loop_check(piattr->aspath, peer->as)) {
 		if (bgp_debug_update(NULL, p, subgrp->update_group, 0))
 			zlog_debug(

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9046,6 +9046,9 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, "i");
 	else
 		vty_out(vty, " ");
+
+	/* adding space between next column */
+	vty_out(vty, " ");
 }
 
 static char *bgp_nexthop_hostname(struct peer *peer,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -66,8 +66,8 @@ enum bgp_show_adj_route_type {
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_RPKI_HEADER                                                   \
 	"RPKI validation codes: V valid, I invalid, N Not found\n\n"
-#define BGP_SHOW_HEADER "    Network          Next Hop            Metric LocPrf Weight Path\n"
-#define BGP_SHOW_HEADER_WIDE "    Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER "     Network          Next Hop            Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER_WIDE "     Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We
  * really do only 1 for MPLS (BGP-LU) but we can do 2 for EVPN-VxLAN.

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4460,6 +4460,13 @@ static void bgp_route_map_update_peer_group(const char *rmap_name,
 					       filter->map[direct].name)
 					== 0))
 					filter->map[direct].map = map;
+
+				if (group->conf->default_rmap[afi][safi].name &&
+				    strmatch(group->conf->default_rmap[afi][safi]
+						     .name,
+					     rmap_name))
+					group->conf->default_rmap[afi][safi].map =
+						map;
 			}
 
 			if (filter->usmap.name

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -239,7 +239,11 @@ static ssize_t printfrr_bd(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (!dest)
 		return bputs(buf, "(null)");
 
+#if !defined(DEV_BUILD)
 	/* need to get the real length even if buffer too small */
 	prefix2str(p, cbuf, sizeof(cbuf));
 	return bputs(buf, cbuf);
+#else
+	return bprintfrr(buf, "%s(%p)", prefix2str(p, cbuf, sizeof(cbuf)), dest);
+#endif
 }

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -443,7 +443,7 @@ static unsigned int updgrp_hash_key_make(const void *p)
 	key = jhash_1word((peer->flags & PEER_FLAG_AIGP), key);
 
 	if (peer->soo[afi][safi]) {
-		char *soo_str = ecommunity_str(peer->soo[afi][safi]);
+		const char *soo_str = ecommunity_str(peer->soo[afi][safi]);
 
 		key = jhash_1word(jhash(soo_str, strlen(soo_str), SEED1), key);
 	}

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -441,7 +441,7 @@ extern struct bgp_adj_out *bgp_adj_out_alloc(struct update_subgroup *subgrp,
 extern void bgp_adj_out_remove_subgroup(struct bgp_dest *dest,
 					struct bgp_adj_out *adj,
 					struct update_subgroup *subgrp);
-extern void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
+extern bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 				     struct update_subgroup *subgrp,
 				     struct attr *attr,
 				     struct bgp_path_info *path);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -520,7 +520,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 	return next;
 }
 
-void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
+bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 			      struct update_subgroup *subgrp, struct attr *attr,
 			      struct bgp_path_info *path)
 {
@@ -540,7 +540,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	bgp = SUBGRP_INST(subgrp);
 
 	if (DISABLE_BGP_ANNOUNCE)
-		return;
+		return false;
 
 	/* Look for adjacency information. */
 	adj = adj_lookup(
@@ -556,7 +556,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 			bgp_addpath_id_for_peer(peer, afi, safi,
 						&path->tx_addpath));
 		if (!adj)
-			return;
+			return false;
 
 		subgrp->pscount++;
 	}
@@ -595,7 +595,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 		 * will never be able to coalesce the 3rd peer down
 		 */
 		subgrp->version = MAX(subgrp->version, dest->version);
-		return;
+		return false;
 	}
 
 	if (adj->adv)
@@ -643,6 +643,8 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	bgp_adv_fifo_add_tail(&subgrp->sync->update, adv);
 
 	subgrp->version = MAX(subgrp->version, dest->version);
+
+	return true;
 }
 
 /* The only time 'withdraw' will be false is if we are sending
@@ -852,7 +854,7 @@ void subgroup_announce_route(struct update_subgroup *subgrp)
 void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 {
 	struct bgp *bgp;
-	struct attr attr;
+	struct attr attr = { 0 };
 	struct attr *new_attr = &attr;
 	struct aspath *aspath;
 	struct prefix p;
@@ -993,18 +995,19 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 		if (dest) {
 			for (pi = bgp_dest_get_bgp_path_info(dest); pi;
 			     pi = pi->next) {
-				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
-					if (subgroup_announce_check(
-						    dest, pi, subgrp,
-						    bgp_dest_get_prefix(dest),
-						    &attr, NULL)) {
-						struct attr *default_attr =
-							bgp_attr_intern(&attr);
+				if (!CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+					continue;
 
-						bgp_adj_out_set_subgroup(
-							dest, subgrp,
-							default_attr, pi);
-					}
+				if (subgroup_announce_check(dest, pi, subgrp,
+							    bgp_dest_get_prefix(
+								    dest),
+							    &attr, NULL)) {
+					if (!bgp_adj_out_set_subgroup(dest,
+								      subgrp,
+								      &attr, pi))
+						bgp_attr_flush(&attr);
+				} else
+					bgp_attr_flush(&attr);
 			}
 			bgp_dest_unlock_node(dest);
 		}

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -854,6 +854,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 	struct bgp *bgp;
 	struct attr attr;
 	struct attr *new_attr = &attr;
+	struct aspath *aspath;
 	struct prefix p;
 	struct peer *from;
 	struct bgp_dest *dest;
@@ -891,6 +892,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 	/* make coverity happy */
 	assert(attr.aspath);
 
+	aspath = attr.aspath;
 	attr.med = 0;
 	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 
@@ -1046,7 +1048,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 		}
 	}
 
-	aspath_unintern(&attr.aspath);
+	aspath_unintern(&aspath);
 }
 
 /*

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14127,33 +14127,28 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					    CHECK_FLAG(
 						    p->af_cap[afi][safi],
 						    PEER_CAP_ADDPATH_AF_TX_RCV)) {
-						if (CHECK_FLAG(
-							    p->af_cap[afi]
-								     [safi],
-							    PEER_CAP_ADDPATH_AF_TX_ADV) &&
-						    CHECK_FLAG(
-							    p->af_cap[afi]
-								     [safi],
-							    PEER_CAP_ADDPATH_AF_TX_RCV))
-							json_object_boolean_true_add(
-								json_sub,
-								"txAdvertisedAndReceived");
-						else if (
-							CHECK_FLAG(
-								p->af_cap[afi]
-									 [safi],
-								PEER_CAP_ADDPATH_AF_TX_ADV))
-							json_object_boolean_true_add(
-								json_sub,
-								"txAdvertised");
-						else if (
-							CHECK_FLAG(
-								p->af_cap[afi]
-									 [safi],
-								PEER_CAP_ADDPATH_AF_TX_RCV))
-							json_object_boolean_true_add(
-								json_sub,
-								"txReceived");
+						json_object_boolean_add(
+							json_sub,
+							"txAdvertisedAndReceived",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_TX_ADV) &&
+								CHECK_FLAG(
+									p->af_cap[afi]
+										 [safi],
+									PEER_CAP_ADDPATH_AF_TX_RCV));
+
+						json_object_boolean_add(
+							json_sub, "txAdvertised",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_TX_ADV));
+
+						json_object_boolean_add(
+							json_sub, "txReceived",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_TX_RCV));
 					}
 
 					if (CHECK_FLAG(
@@ -14162,33 +14157,28 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					    CHECK_FLAG(
 						    p->af_cap[afi][safi],
 						    PEER_CAP_ADDPATH_AF_RX_RCV)) {
-						if (CHECK_FLAG(
-							    p->af_cap[afi]
-								     [safi],
-							    PEER_CAP_ADDPATH_AF_RX_ADV) &&
-						    CHECK_FLAG(
-							    p->af_cap[afi]
-								     [safi],
-							    PEER_CAP_ADDPATH_AF_RX_RCV))
-							json_object_boolean_true_add(
-								json_sub,
-								"rxAdvertisedAndReceived");
-						else if (
-							CHECK_FLAG(
-								p->af_cap[afi]
-									 [safi],
-								PEER_CAP_ADDPATH_AF_RX_ADV))
-							json_object_boolean_true_add(
-								json_sub,
-								"rxAdvertised");
-						else if (
-							CHECK_FLAG(
-								p->af_cap[afi]
-									 [safi],
-								PEER_CAP_ADDPATH_AF_RX_RCV))
-							json_object_boolean_true_add(
-								json_sub,
-								"rxReceived");
+						json_object_boolean_add(
+							json_sub,
+							"rxAdvertisedAndReceived",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_RX_ADV) &&
+								CHECK_FLAG(
+									p->af_cap[afi]
+										 [safi],
+									PEER_CAP_ADDPATH_AF_RX_RCV));
+
+						json_object_boolean_add(
+							json_sub, "rxAdvertised",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_RX_ADV));
+
+						json_object_boolean_add(
+							json_sub, "rxReceived",
+							CHECK_FLAG(p->af_cap[afi]
+									    [safi],
+								   PEER_CAP_ADDPATH_AF_RX_RCV));
 					}
 
 					if (CHECK_FLAG(

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9261,7 +9261,7 @@ DEFPY (no_neighbor_addpath_paths_limit,
 	peer->addpath_paths_limit[afi][safi].send = 0;
 
 	bgp_capability_send(peer, afi, safi, CAPABILITY_CODE_PATHS_LIMIT,
-			    CAPABILITY_ACTION_UNSET);
+			    CAPABILITY_ACTION_SET);
 
 	return ret;
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9198,15 +9198,7 @@ DEFPY(
 	NEIGHBOR_ADDR_STR2
 	"Detect AS loops before sending to neighbor\n")
 {
-	struct peer *peer;
-
-	peer = peer_and_group_lookup_vty(vty, neighbor);
-	if (!peer)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	peer->as_path_loop_detection = true;
-
-	return CMD_SUCCESS;
+	return peer_flag_set_vty(vty, neighbor, PEER_FLAG_AS_LOOP_DETECTION);
 }
 
 DEFPY (neighbor_addpath_paths_limit,
@@ -9275,15 +9267,7 @@ DEFPY(
 	NEIGHBOR_ADDR_STR2
 	"Detect AS loops before sending to neighbor\n")
 {
-	struct peer *peer;
-
-	peer = peer_and_group_lookup_vty(vty, neighbor);
-	if (!peer)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	peer->as_path_loop_detection = false;
-
-	return CMD_SUCCESS;
+	return peer_flag_unset_vty(vty, neighbor, PEER_FLAG_AS_LOOP_DETECTION);
 }
 
 DEFPY(neighbor_path_attribute_discard,
@@ -18460,7 +18444,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, " neighbor %s strict-capability-match\n", addr);
 
 	/* Sender side AS path loop detection. */
-	if (peer->as_path_loop_detection)
+	if (peergroup_flag_check(peer, PEER_FLAG_AS_LOOP_DETECTION))
 		vty_out(vty, " neighbor %s sender-as-path-loop-detection\n",
 			addr);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4587,6 +4587,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_GRACEFUL_SHUTDOWN, 0, peer_change_none},
 	{PEER_FLAG_CAPABILITY_SOFT_VERSION, 0, peer_change_none},
 	{PEER_FLAG_CAPABILITY_FQDN, 0, peer_change_none},
+	{PEER_FLAG_AS_LOOP_DETECTION, 0, peer_change_none},
 	{0, 0, 0}};
 
 static const struct peer_flag_action peer_af_flag_action_list[] = {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1470,6 +1470,7 @@ struct peer {
 #define PEER_FLAG_GRACEFUL_SHUTDOWN (1ULL << 35)
 #define PEER_FLAG_CAPABILITY_SOFT_VERSION (1ULL << 36)
 #define PEER_FLAG_CAPABILITY_FQDN (1ULL << 37)  /* fqdn capability */
+#define PEER_FLAG_AS_LOOP_DETECTION (1ULL << 38) /* as path loop detection */
 
 	/*
 	 *GR-Disabled mode means unset PEER_FLAG_GRACEFUL_RESTART
@@ -1822,9 +1823,6 @@ struct peer {
 	/* hostname and domainname advertised by host */
 	char *hostname;
 	char *domainname;
-
-	/* Sender side AS path loop detection. */
-	bool as_path_loop_detection;
 
 	/* Extended Message Support */
 	uint16_t max_packet_size;

--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -383,7 +383,8 @@ bgpd
 
 .. frrfmt:: %pBD (struct bgp_dest *)
 
-   Print prefix for a BGP destination.
+   Print prefix for a BGP destination.  When using ``--enable-dev-build`` include
+   the pointer value for the bgp_dest.
 
    :frrfmtout:`fe80::1234/64`
 

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -94,9 +94,10 @@ static void sighup(void)
 static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
-	eigrp_terminate();
 
 	keychain_terminate();
+
+	eigrp_terminate();
 
 	exit(0);
 }

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -957,8 +957,6 @@ static void frr_daemonize(void)
 	}
 
 	close(fds[1]);
-	nb_terminate();
-	yang_terminate();
 	frr_daemon_wait(fds[0]);
 }
 

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -240,7 +240,17 @@ core_handler(int signo, siginfo_t *siginfo, void *context)
 	/* dump memory stats on core */
 	log_memstats(stderr, "core_handler");
 
-	zlog_tls_buffer_fini();
+	/*
+	 * This is a buffer flush because FRR is going down
+	 * hard.  This is especially important if the crash
+	 * was caused by a memory operation and if we call
+	 * zlog_tls_buffer_fini() then it has memory
+	 * operations as well.  This will cause the
+	 * core dump to not happen.  BAD MOJO
+	 * So this is intentional, let's try to flush
+	 * what we can and let the crash happen.
+	 */
+	zlog_tls_buffer_flush();
 
 	/* give the kernel a chance to generate a coredump */
 	sigaddset(&sigset, signo);

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -202,6 +202,12 @@ extern void vrf_init(int (*create)(struct vrf *vrf),
 		     int (*destroy)(struct vrf *vrf));
 
 /*
+ * Iterate over custom VRFs and round up by processing the default VRF.
+ */
+typedef void (*vrf_iter_func)(struct vrf *vrf);
+extern void vrf_iterate(vrf_iter_func fnc);
+
+/*
  * Call vrf_terminate when the protocol is being shutdown
  */
 extern void vrf_terminate(void);

--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -133,8 +133,10 @@ static void sigusr1(void)
 static void quit(int exit_code)
 {
 	EVENT_OFF(event_timeout);
-	frr_fini();
 	darr_free(__client_cbs.notif_xpaths);
+
+	frr_fini();
+
 	exit(exit_code);
 }
 

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -110,9 +110,10 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 
 	ospf6_master_delete();
 
+	keychain_terminate();
+
 	frr_fini();
 
-	keychain_terminate();
 	exit(status);
 }
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1486,12 +1486,8 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 		/* Packet overflows MTU size, send immediately. */
 		if (length + ntohs(find->data->length) > ospf_packet_max(oi)) {
-			if (oi->type == OSPF_IFTYPE_NBMA)
-				ospf_ls_upd_send(nbr, ls_upd,
-						 OSPF_SEND_PACKET_DIRECT, 0);
-			else
-				ospf_ls_upd_send(nbr, ls_upd,
-						 OSPF_SEND_PACKET_INDIRECT, 0);
+			ospf_ls_upd_send(nbr, ls_upd,
+					 OSPF_SEND_PACKET_DIRECT, 0);
 
 			/* Only remove list contents.  Keep ls_upd. */
 			list_delete_all_node(ls_upd);
@@ -1508,12 +1504,7 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 	/* Send rest of Link State Update. */
 	if (listcount(ls_upd) > 0) {
-		if (oi->type == OSPF_IFTYPE_NBMA)
-			ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_DIRECT,
-					 0);
-		else
-			ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_INDIRECT,
-					 0);
+		ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_DIRECT, 0);
 
 		list_delete(&ls_upd);
 	} else

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0      0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0/24   0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0/24   0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0      0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/bgp_dynamic_capability/r1/frr.conf
+++ b/tests/topotests/bgp_dynamic_capability/r1/frr.conf
@@ -15,6 +15,7 @@ router bgp 65001
  !
  address-family ipv4 unicast
   neighbor 192.168.1.2 addpath-tx-all-paths
+  neighbor 192.168.1.2 addpath-rx-paths-limit 10
  exit-address-family
 !
 ip prefix-list r2 seq 5 permit 10.10.10.10/32

--- a/tests/topotests/bgp_dynamic_capability/r2/frr.conf
+++ b/tests/topotests/bgp_dynamic_capability/r2/frr.conf
@@ -16,6 +16,7 @@ router bgp 65002
  neighbor 192.168.1.1 timers 1 3
  neighbor 192.168.1.1 timers connect 1
  neighbor 192.168.1.1 capability dynamic
+ neighbor 192.168.1.1 addpath-rx-paths-limit 20
  !
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/add_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/add_routes.py
@@ -9,9 +9,9 @@ luCommand(
 luCommand(
     "r4", 'vtysh -c "show bgp next"', "99.0.0.. valid", "wait", "See CE static NH"
 )
-luCommand("r1", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
-luCommand("r3", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
-luCommand("r4", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
+luCommand("r1", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
+luCommand("r3", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
+luCommand("r4", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
 luCommand("ce1", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
 luCommand("r1", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
 luCommand("ce2", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
@@ -39,22 +39,22 @@ luCommand(
 luCommand(
     "r3",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.1/32",
+    "i 99.0.0.1/32",
     "wait",
     "See R1s static address",
 )
 luCommand(
     "r4",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.1/32",
+    "i 99.0.0.1/32",
     "wait",
     "See R1s static address",
 )
 luCommand(
-    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i5.*i5", "wait", "See R1s imports"
+    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i 5.*i 5", "wait", "See R1s imports"
 )
 luCommand(
-    "r4", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i5.*i5", "wait", "See R1s imports"
+    "r4", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i 5.*i 5", "wait", "See R1s imports"
 )
 
 luCommand(
@@ -86,14 +86,14 @@ if have2ndImports:
 luCommand(
     "r1",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.2/32",
+    "i 99.0.0.2/32",
     "wait",
     "See R3s static address",
 )
 luCommand(
     "r4",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.2/32",
+    "i 99.0.0.2/32",
     "wait",
     "See R3s static address",
 )
@@ -101,14 +101,14 @@ if have2ndImports:
     luCommand(
         "r1",
         'vtysh -c "show bgp ipv4 vpn rd 10:3"',
-        "i5.*i5",
+        "i 5.*i 5",
         "none",
         "See R3s imports",
     )
     luCommand(
         "r4",
         'vtysh -c "show bgp ipv4 vpn rd 10:3"',
-        "i5.*i5",
+        "i 5.*i 5",
         "none",
         "See R3s imports",
     )
@@ -133,22 +133,22 @@ luCommand(
 luCommand(
     "r1",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.3/32",
+    "i 99.0.0.3/32",
     "wait",
     "See R4s static address",
 )
 luCommand(
     "r3",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.3/32",
+    "i 99.0.0.3/32",
     "wait",
     "See R4s static address",
 )
 luCommand(
-    "r1", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i5.*i5", "wait", "See R4s imports"
+    "r1", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i 5.*i 5", "wait", "See R4s imports"
 )
 luCommand(
-    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i5.*i5", "wait", "See R4s imports"
+    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i 5.*i 5", "wait", "See R4s imports"
 )
 
 

--- a/tests/topotests/bgp_sender_as_path_loop_detection/test_bgp_sender-as-path-loop-detection.py
+++ b/tests/topotests/bgp_sender_as_path_loop_detection/test_bgp_sender-as-path-loop-detection.py
@@ -129,6 +129,83 @@ def test_bgp_sender_as_path_loop_detection():
     assert result is None, "Routes should not be sent to r1 from r2"
 
 
+def test_remove_loop_detection_on_one_peer():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    def _bgp_reset_route_to_r1():
+        output = json.loads(
+            r2.vtysh_cmd("show ip bgp neighbor 192.168.255.2 advertised-routes json")
+        )
+        expected = {"totalPrefixCounter": 3}
+        return topotest.json_cmp(output, expected)
+
+    r2.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65002
+          no neighbor 192.168.255.2 sender-as-path-loop-detection
+        """
+    )
+
+    r2.vtysh_cmd(
+        """
+        clear bgp *
+        """
+    )
+    test_func = functools.partial(_bgp_reset_route_to_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert result is None, "Failed bgp to reset route"
+
+
+def test_loop_detection_on_peer_group():
+    tgen = get_topogen()
+
+    r2 = tgen.gears["r2"]
+
+    def _bgp_suppress_route_to_r1():
+        output = json.loads(
+            r2.vtysh_cmd("show ip bgp neighbor 192.168.255.2 advertised-routes json")
+        )
+        expected = {"totalPrefixCounter": 0}
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_suppress_route_to_r3():
+        output = json.loads(
+            r2.vtysh_cmd("show ip bgp neighbor 192.168.254.2 advertised-routes json")
+        )
+        expected = {"totalPrefixCounter": 2}
+        return topotest.json_cmp(output, expected)
+
+    r2.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 65002
+          neighbor loop_group peer-group
+          neighbor 192.168.255.2 peer-group loop_group
+          neighbor loop_group sender-as-path-loop-detection
+        """
+    )
+
+    r2.vtysh_cmd(
+        """
+        clear bgp *
+        """
+    )
+
+    test_func = functools.partial(_bgp_suppress_route_to_r3)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert result is None, "Route 172.16.255.253/32 should not be sent to r3 from r2"
+
+    test_func = functools.partial(_bgp_suppress_route_to_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    assert result is None, "Routes should not be sent to r1 from r2"
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/fpm_listener.c
+++ b/zebra/fpm_listener.c
@@ -32,6 +32,7 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 
+#include "rt_netlink.h"
 #include "fpm/fpm.h"
 #include "lib/libfrr.h"
 
@@ -238,6 +239,39 @@ netlink_prot_to_s(unsigned char prot)
 
 	case RTPROT_DHCP:
 		return "Dhcp";
+
+	case RTPROT_BGP:
+		return "BGP";
+
+	case RTPROT_ISIS:
+		return "ISIS";
+
+	case RTPROT_OSPF:
+		return "OSPF";
+
+	case RTPROT_RIP:
+		return "RIP";
+
+	case RTPROT_RIPNG:
+		return "RIPNG";
+
+	case RTPROT_BABEL:
+		return "BABEL";
+
+	case RTPROT_NHRP:
+		return "NHRP";
+
+	case RTPROT_EIGRP:
+		return "EIGRP";
+
+	case RTPROT_SHARP:
+		return "SHARP";
+
+	case RTPROT_PBR:
+		return "PBR";
+
+	case RTPROT_ZSTATIC:
+		return "Static";
 
 	default:
 		return "Unknown";

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -205,6 +205,12 @@ static void sigint(void)
 	list_delete(&zrouter.client_list);
 	list_delete(&zrouter.stale_client_list);
 
+	/*
+	 * Besides other clean-ups zebra's vrf_disable() also enqueues installed
+	 * routes for removal from the kernel, unless ZEBRA_VRF_RETAIN is set.
+	 */
+	vrf_iterate(vrf_disable);
+
 	/* Indicate that all new dplane work has been enqueued. When that
 	 * work is complete, the dataplane will enqueue an event
 	 * with the 'finalize' function.

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -6351,7 +6351,7 @@ dplane_provider_dequeue_out_ctx(struct zebra_dplane_provider *prov)
  */
 bool dplane_provider_is_threaded(const struct zebra_dplane_provider *prov)
 {
-	return (prov->dp_flags & DPLANE_PROV_FLAG_THREADED);
+	return CHECK_FLAG(prov->dp_flags, DPLANE_PROV_FLAG_THREADED);
 }
 
 #ifdef HAVE_NETLINK

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -592,19 +592,19 @@ int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
 				RTM_DELNEIGH : RTM_NEWNEIGH;
 	req->hdr.nlmsg_flags = NLM_F_REQUEST;
 	if (req->hdr.nlmsg_type == RTM_NEWNEIGH)
-		req->hdr.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
+		SET_FLAG(req->hdr.nlmsg_flags, (NLM_F_CREATE | NLM_F_REPLACE));
 
 	/* Construct ndmsg */
 	req->ndm.ndm_family = AF_BRIDGE;
 	req->ndm.ndm_ifindex = mac->vxlan_if;
 
 	req->ndm.ndm_state = NUD_REACHABLE;
-	req->ndm.ndm_flags |= NTF_SELF | NTF_MASTER;
+	SET_FLAG(req->ndm.ndm_flags, (NTF_SELF | NTF_MASTER));
 	if (CHECK_FLAG(mac->zebra_flags,
 		(ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW)))
-		req->ndm.ndm_state |= NUD_NOARP;
+		SET_FLAG(req->ndm.ndm_state, NUD_NOARP);
 	else
-		req->ndm.ndm_flags |= NTF_EXT_LEARNED;
+		SET_FLAG(req->ndm.ndm_flags, NTF_EXT_LEARNED);
 
 	/* Add attributes */
 	nl_attr_put(&req->hdr, in_buf_len, NDA_LLADDR, &mac->macaddr, 6);

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -298,6 +298,16 @@ struct zebra_gr_afi_clean {
  * Functions to deal with capabilities
  */
 
+void zebra_gr_client_final_shutdown(struct zserv *client)
+{
+	struct client_gr_info *info;
+
+	while (!TAILQ_EMPTY(&client->gr_info_queue)) {
+		info = TAILQ_FIRST(&client->gr_info_queue);
+		zebra_gr_client_info_delete(client, info);
+	}
+}
+
 /*
  * Function to decode and call appropriate functions
  * to handle client capabilities.

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -329,7 +329,7 @@ static void fec_evaluate(struct zebra_vrf *zvrf)
 
 			/* Skip configured FECs and those without a label index.
 			 */
-			if (fec->flags & FEC_FLAG_CONFIGURED
+			if (CHECK_FLAG(fec->flags, FEC_FLAG_CONFIGURED)
 			    || fec->label_index == MPLS_INVALID_LABEL_INDEX)
 				continue;
 
@@ -2420,7 +2420,7 @@ static int zebra_mpls_cleanup_fecs_for_client(struct zserv *client)
 				if (fec_client == client) {
 					listnode_delete(fec->client_list,
 							fec_client);
-					if (!(fec->flags & FEC_FLAG_CONFIGURED)
+					if (!CHECK_FLAG(fec->flags, FEC_FLAG_CONFIGURED)
 					    && list_isempty(fec->client_list))
 						fec_del(fec);
 					break;
@@ -2538,7 +2538,7 @@ int zebra_mpls_static_fec_add(struct zebra_vrf *zvrf, struct prefix *p,
 		if (IS_ZEBRA_DEBUG_MPLS)
 			zlog_debug("Add fec %pFX label %u", p, in_label);
 	} else {
-		fec->flags |= FEC_FLAG_CONFIGURED;
+		SET_FLAG(fec->flags, FEC_FLAG_CONFIGURED);
 		if (fec->label == in_label)
 			/* Duplicate config */
 			return 0;
@@ -2587,7 +2587,7 @@ int zebra_mpls_static_fec_del(struct zebra_vrf *zvrf, struct prefix *p)
 	}
 
 	old_label = fec->label;
-	fec->flags &= ~FEC_FLAG_CONFIGURED;
+	UNSET_FLAG(fec->flags, FEC_FLAG_CONFIGURED);
 	fec->label = MPLS_INVALID_LABEL;
 
 	/* If no client exists, just delete the FEC. */
@@ -2630,7 +2630,7 @@ int zebra_mpls_write_fec_config(struct vty *vty, struct zebra_vrf *zvrf)
 			char lstr[BUFSIZ];
 			fec = rn->info;
 
-			if (!(fec->flags & FEC_FLAG_CONFIGURED))
+			if (!CHECK_FLAG(fec->flags, FEC_FLAG_CONFIGURED))
 				continue;
 
 			write = 1;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -3102,7 +3102,7 @@ int lib_interface_zebra_ipv6_router_advertisements_rdnss_rdnss_address_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
-	struct rtadv_rdnss rdnss = {0}, *p;
+	struct rtadv_rdnss rdnss = {{{{0}}}}, *p;
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -3181,7 +3181,7 @@ int lib_interface_zebra_ipv6_router_advertisements_dnssl_dnssl_domain_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
-	struct rtadv_dnssl dnssl = {0}, *p;
+	struct rtadv_dnssl dnssl = {{0}}, *p;
 	int ret;
 
 	strlcpy(dnssl.name, yang_dnode_get_string(args->dnode, "domain"),

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -675,10 +675,14 @@ static void zserv_client_free(struct zserv *client)
 	 * If any instance are graceful restart enabled,
 	 * client is not deleted
 	 */
-	if (DYNAMIC_CLIENT_GR_DISABLED(client)) {
+	if (DYNAMIC_CLIENT_GR_DISABLED(client) || zebra_router_in_shutdown()) {
 		if (IS_ZEBRA_DEBUG_EVENT)
 			zlog_debug("%s: Deleting client %s", __func__,
 				   zebra_route_string(client->proto));
+
+		if (zebra_router_in_shutdown())
+			zebra_gr_client_final_shutdown(client);
+
 		zserv_client_delete(client);
 	} else {
 		/* Handle cases where client has GR instance. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -378,6 +378,7 @@ __attribute__((__noreturn__)) void zebra_finalize(struct event *event);
 /*
  * Graceful restart functions.
  */
+extern void zebra_gr_client_final_shutdown(struct zserv *client);
 extern int zebra_gr_client_disconnect(struct zserv *client);
 extern void zebra_gr_client_reconnect(struct zserv *client);
 extern void zebra_gr_stale_client_cleanup(struct list *client_list);


### PR DESCRIPTION
…columns

When running `show ip bgp` command, the 'route short status' and
    'network' columns do not have white-space between them.

    Old show:
        Network          Next Hop            Metric LocPrf Weight Path
     *>i1.1.1.1/32       10.1.12.111              0    100      0 i

    New show:
         Network          Next Hop            Metric LocPrf Weight Path
     *>i 1.1.1.1/32       10.1.12.111              0    100      0 i

    Added white-space to enhance readability between them.